### PR TITLE
Rename `tag` to `id`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -39,7 +39,7 @@ A [=service worker registration=] has an associated <dfn for="service worker reg
 A <dfn>background fetch</dfn> consists of:
 
 <div dfn-for="background fetch">
-  * A <dfn>tag</dfn>, which is a DOMString.
+  * An <dfn>id</dfn>, which is a DOMString.
   * TODO: add additional state
 </div>
 
@@ -60,9 +60,9 @@ The <dfn attribute for="ServiceWorkerRegistration">backgroundFetch</dfn> attribu
 <pre class="idl">
   [Exposed=(Window,Worker)]
   interface BackgroundFetchManager {
-    Promise&lt;BackgroundFetchRegistration&gt; fetch(DOMString tag, (RequestInfo or sequence&lt;RequestInfo&gt;) requests, optional BackgroundFetchOptions options);
-    Promise&lt;BackgroundFetchRegistration?&gt; get(DOMString tag);
-    Promise&lt;FrozenArray&lt;DOMString&gt;&gt; getTags();
+    Promise&lt;BackgroundFetchRegistration&gt; fetch(DOMString id, (RequestInfo or sequence&lt;RequestInfo&gt;) requests, optional BackgroundFetchOptions options);
+    Promise&lt;BackgroundFetchRegistration?&gt; get(DOMString id);
+    Promise&lt;FrozenArray&lt;DOMString&gt;&gt; getIdentifiers();
     // TODO: in future this should become an async iterator for BackgroundFetchRegistration objects
   };
 
@@ -83,20 +83,20 @@ The <dfn attribute for="ServiceWorkerRegistration">backgroundFetch</dfn> attribu
 
 <div dfn-for="BackgroundFetchManager">
   <div algorithm>
-    The <dfn method>fetch(|tag|, |requests|, |options|)</dfn> method, when invoked, must return [=a new promise=] |promise| and run the following steps [=in parallel=]:
+    The <dfn method>fetch(|id|, |requests|, |options|)</dfn> method, when invoked, must return [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
       1. Let |registration| be the [=context object=]'s associated [=/service worker registration=].
       1. TODO.
   </div>
 
   <div algorithm>
-    The <dfn method>get(|tag|)</dfn> method, when invoked, must return [=a new promise=] |promise| and run the following steps [=in parallel=]:
+    The <dfn method>get(|id|)</dfn> method, when invoked, must return [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
       1. TODO
   </div>
 
   <div algorithm>
-    The <dfn method>getTags()</dfn> method, when invoked, must return [=a new promise=] |promise| and run the following steps [=in parallel=]:
+    The <dfn method>getIdentifiers()</dfn> method, when invoked, must return [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
       1. TODO
   </div>
@@ -107,7 +107,7 @@ The <dfn attribute for="ServiceWorkerRegistration">backgroundFetch</dfn> attribu
 <pre class="idl">
   [Exposed=(Window,Worker)]
   interface BackgroundFetchRegistration {
-    readonly attribute DOMString tag;
+    readonly attribute DOMString id;
     readonly attribute FrozenArray&lt;IconDefinition&gt; icons;
     readonly attribute long totalDownloadSize;
     readonly attribute DOMString title;
@@ -184,19 +184,19 @@ The following is the <a>event handler</a> (and its corresponding <a>event handle
 <pre class="idl">
   [Constructor(DOMString type, BackgroundFetchEventInit init), Exposed=ServiceWorker]
   interface BackgroundFetchEvent : ExtendableEvent {
-    readonly attribute DOMString tag;
+    readonly attribute DOMString id;
   };
 
   dictionary BackgroundFetchEventInit : ExtendableEventInit {
-    required DOMString tag;
+    required DOMString id;
   };
 </pre>
 
 <div dfn-for="BackgroundFetchEvent">
-  A {{BackgroundFetchEvent}} has an associated <dfn>tag</dfn>, a DOMString.
+  A {{BackgroundFetchEvent}} has an associated <dfn>id</dfn>, a DOMString.
 
-  The <dfn attribute>tag</dfn> attribute must return the [=BackgroundFetchEvent/tag=].
-  
+  The <dfn attribute>id</dfn> attribute must return the [=BackgroundFetchEvent/id=].
+
   TODO
 </div>
 

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: normal;
+		font-size: medium;
 	}
 	dfn var {
 		font-style: normal;
@@ -1176,7 +1176,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 70f542b3eb403344eee83c57e6631f734b1c4427" name="generator">
+  <meta content="Bikeshed version 63e2d3f6cc034d9b09cfdb2d391c527b191584bc" name="generator">
+  <link href="https://jakearchibald.github.io/background-fetch" rel="canonical">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1363,84 +1364,84 @@ Possible extra rowspan handling
         </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-        code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        </style>
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Background Fetch</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-21">21 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-08-07">7 August 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://jakearchibald.github.io/background-fetch">https://jakearchibald.github.io/background-fetch</a>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/WICG/background-fetch/issues/">GitHub</a>
+     <dd><a href="https://github.com/beverloo/background-fetch/issues/">GitHub</a>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:jakearchibald@google.com">Jake Archibald</a> (<span class="p-org org">Google</span>)
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 the Contributors to the Background Fetch Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 the Contributors to the Background Fetch Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
-  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>An API to handle large uploads/downloads in the background with user visibility.</p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1492,196 +1493,196 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a> is capable of fetching and caching assets, the size of which is restricted only by <a href="https://storage.spec.whatwg.org/#usage-and-quota">origin storage</a>. However, if the user navigates away from the site or closes the browser, the service worker is <a href="https://w3c.github.io/ServiceWorker/#service-worker-lifetime">likely to be killed</a>. This can happen even if there’s a pending promise passed to <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil">waitUntil()</a></code>; if it hasn’t resolved within a few minutes the browser may consider it an abuse of <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a> and kill the process.</p>
-   <p>This makes it difficult to download and cache large assets such as podcasts and movies, and upload video and images. Even if the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a> isn’t killed, having to keep the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a> in memory during this potentially long operation is wasteful.</p>
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker">service worker</a> is capable of fetching and caching assets, the size of which is restricted only by <a href="https://storage.spec.whatwg.org/#usage-and-quota">origin storage</a>. However, if the user navigates away from the site or closes the browser, the service worker is <a href="https://www.w3.org/TR/service-workers-1/#service-worker-lifetime">likely to be killed</a>. This can happen even if there’s a pending promise passed to <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil">waitUntil()</a></code>; if it hasn’t resolved within a few minutes the browser may consider it an abuse of <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker-0">service worker</a> and kill the process.</p>
+   <p>This makes it difficult to download and cache large assets such as podcasts and movies, and upload video and images. Even if the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker-1">service worker</a> isn’t killed, having to keep the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker-2">service worker</a> in memory during this potentially long operation is wasteful.</p>
    <p>This specification aims to:</p>
    <ul>
     <li data-md="">
-     <p>Allow <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetches</a> to continue even if the user closes all windows &amp; worker to the origin.</p>
+     <p>Allow <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch">fetches</a> to continue even if the user closes all windows &amp; worker to the origin.</p>
     <li data-md="">
      <p>Allow a single job to involve many requests, as defined by the app.</p>
     <li data-md="">
-     <p>Allow the browser/OS to show UI to indicate the progress of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>, and allow the user to pause/abort.</p>
+     <p>Allow the browser/OS to show UI to indicate the progress of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch-0">fetch</a>, and allow the user to pause/abort.</p>
     <li data-md="">
      <p>Allow the browser/OS to deal with poor connectivity by pausing/resuming the download/upload (may be tricky with uploads, as ranged uploads aren’t standardized)</p>
     <li data-md="">
      <p>Allow the app to react to success/failure of the background fetch group, perhaps by caching the results.</p>
     <li data-md="">
-     <p>Allow access to background-fetched resources as they <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>.</p>
+     <p>Allow access to background-fetched resources as they <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch-1">fetch</a>.</p>
     <li data-md="">
      <p>Allow the app to display progress information about a background fetch.</p>
     <li data-md="">
-     <p>Allow the app to suggest which connection types the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> should be restricted to.</p>
+     <p>Allow the app to suggest which connection types the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch-2">fetch</a> should be restricted to.</p>
    </ul>
    <h2 class="heading settled" data-level="2" id="infrastructure"><span class="secno">2. </span><span class="content">Infrastructure</span><a class="self-link" href="#infrastructure"></a></h2>
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">service worker registration</a> has an associated <dfn data-dfn-for="service worker registration" data-dfn-type="dfn" data-noexport="" id="service-worker-registration-list-of-active-background-fetches">list of active background fetches<a class="self-link" href="#service-worker-registration-list-of-active-background-fetches"></a></dfn> a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">list</a> where each item is a <a data-link-type="dfn" href="#background-fetch" id="ref-for-background-fetch-1">background fetch</a>.</p>
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration">service worker registration</a> has an associated <dfn data-dfn-for="service worker registration" data-dfn-type="dfn" data-noexport="" id="service-worker-registration-list-of-active-background-fetches">list of active background fetches<a class="self-link" href="#service-worker-registration-list-of-active-background-fetches"></a></dfn> a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> where each item is a <a data-link-type="dfn" href="#background-fetch" id="ref-for-background-fetch">background fetch</a>.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="background-fetch">background fetch</dfn> consists of:</p>
    <div>
     <ul>
      <li data-md="">
-      <p>A <dfn data-dfn-for="background fetch" data-dfn-type="dfn" data-noexport="" id="background-fetch-tag">tag<a class="self-link" href="#background-fetch-tag"></a></dfn>, which is a DOMString.</p>
+      <p>An <dfn data-dfn-for="background fetch" data-dfn-type="dfn" data-noexport="" id="background-fetch-id">id<a class="self-link" href="#background-fetch-id"></a></dfn>, which is a DOMString.</p>
      <li data-md="">
       <p>TODO: add additional state</p>
     </ul>
    </div>
    <h2 class="heading settled" data-level="3" id="api"><span class="secno">3. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
-   <h3 class="heading settled" data-level="3.1" id="extensions-to-service-worker-registration"><span class="secno">3.1. </span><span class="content">Extensions to <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">ServiceWorkerRegistration</a></code></span><a class="self-link" href="#extensions-to-service-worker-registration"></a></h3>
-<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">ServiceWorkerRegistration</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager-1">BackgroundFetchManager</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="BackgroundFetchManager" href="#dom-serviceworkerregistration-backgroundfetch" id="ref-for-dom-serviceworkerregistration-backgroundfetch-1">backgroundFetch</a>;
+   <h3 class="heading settled" data-level="3.1" id="extensions-to-service-worker-registration"><span class="secno">3.1. </span><span class="content">Extensions to <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration">ServiceWorkerRegistration</a></code></span><a class="self-link" href="#extensions-to-service-worker-registration"></a></h3>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration-0">ServiceWorkerRegistration</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager">BackgroundFetchManager</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="BackgroundFetchManager" href="#dom-serviceworkerregistration-backgroundfetch" id="ref-for-dom-serviceworkerregistration-backgroundfetch">backgroundFetch</a>;
 };
 </pre>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-backgroundfetch">backgroundFetch</dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager-2">BackgroundFetchManager</a></code> object that is associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
-   <h3 class="heading settled" data-level="3.2" id="background-fetch-manager"><span class="secno">3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager-3">BackgroundFetchManager</a></code></span><a class="self-link" href="#background-fetch-manager"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchmanager">BackgroundFetchManager</dfn> {
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-1">BackgroundFetchRegistration</a>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-fetch" id="ref-for-dom-backgroundfetchmanager-fetch-1">fetch</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/fetch(tag, requests, options), BackgroundFetchManager/fetch(tag, requests)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-fetch-tag-requests-options-tag">tag<a class="self-link" href="#dom-backgroundfetchmanager-fetch-tag-requests-options-tag"></a></dfn>, (<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo">RequestInfo</a> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo">RequestInfo</a>>) <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/fetch(tag, requests, options), BackgroundFetchManager/fetch(tag, requests)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-fetch-tag-requests-options-requests">requests<a class="self-link" href="#dom-backgroundfetchmanager-fetch-tag-requests-options-requests"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchoptions" id="ref-for-dictdef-backgroundfetchoptions-1">BackgroundFetchOptions</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/fetch(tag, requests, options), BackgroundFetchManager/fetch(tag, requests)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-fetch-tag-requests-options-options">options<a class="self-link" href="#dom-backgroundfetchmanager-fetch-tag-requests-options-options"></a></dfn>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-2">BackgroundFetchRegistration</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-get" id="ref-for-dom-backgroundfetchmanager-get-1">get</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/get(tag)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-get-tag-tag">tag<a class="self-link" href="#dom-backgroundfetchmanager-get-tag-tag"></a></dfn>);
-  <span class="kt">Promise</span>&lt;<span class="kt">FrozenArray</span>&lt;<span class="kt">DOMString</span>>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-gettags" id="ref-for-dom-backgroundfetchmanager-gettags-1">getTags</a>();
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-backgroundfetch"><code>backgroundFetch</code></dfn> attribute must return the <code class="idl"><a data-link-type="idl" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager-0">BackgroundFetchManager</a></code> object that is associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a>.</p>
+   <h3 class="heading settled" data-level="3.2" id="background-fetch-manager"><span class="secno">3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager-1">BackgroundFetchManager</a></code></span><a class="self-link" href="#background-fetch-manager"></a></h3>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchmanager"><code>BackgroundFetchManager</code></dfn> {
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration">BackgroundFetchRegistration</a>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-fetch" id="ref-for-dom-backgroundfetchmanager-fetch">fetch</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/fetch(id, requests, options), BackgroundFetchManager/fetch(id, requests)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-fetch-id-requests-options-id"><code>id</code><a class="self-link" href="#dom-backgroundfetchmanager-fetch-id-requests-options-id"></a></dfn>, (<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo" id="ref-for-requestinfo">RequestInfo</a> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo" id="ref-for-requestinfo-0">RequestInfo</a>>) <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/fetch(id, requests, options), BackgroundFetchManager/fetch(id, requests)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-fetch-id-requests-options-requests"><code>requests</code><a class="self-link" href="#dom-backgroundfetchmanager-fetch-id-requests-options-requests"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchoptions" id="ref-for-dictdef-backgroundfetchoptions">BackgroundFetchOptions</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/fetch(id, requests, options), BackgroundFetchManager/fetch(id, requests)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-fetch-id-requests-options-options"><code>options</code><a class="self-link" href="#dom-backgroundfetchmanager-fetch-id-requests-options-options"></a></dfn>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-0">BackgroundFetchRegistration</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-get" id="ref-for-dom-backgroundfetchmanager-get">get</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-0"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchManager/get(id)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchmanager-get-id-id"><code>id</code><a class="self-link" href="#dom-backgroundfetchmanager-get-id-id"></a></dfn>);
+  <span class="kt">Promise</span>&lt;<span class="kt">FrozenArray</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-1"><span class="kt">DOMString</span></a>>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-getidentifiers" id="ref-for-dom-backgroundfetchmanager-getidentifiers">getIdentifiers</a>();
   // TODO: in future this should become an async iterator for BackgroundFetchRegistration objects
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchoptions">BackgroundFetchOptions</dfn> {
-  <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition" id="ref-for-dictdef-icondefinition-1">IconDefinition</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="BackgroundFetchOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<IconDefinition> " id="dom-backgroundfetchoptions-icons">icons<a class="self-link" href="#dom-backgroundfetchoptions-icons"></a></dfn> = [];
-  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="BackgroundFetchOptions" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-backgroundfetchoptions-title">title<a class="self-link" href="#dom-backgroundfetchoptions-title"></a></dfn> = "";
-  <span class="kt">long</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="BackgroundFetchOptions" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-backgroundfetchoptions-totaldownloadsize">totalDownloadSize<a class="self-link" href="#dom-backgroundfetchoptions-totaldownloadsize"></a></dfn> = 0;
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchoptions"><code>BackgroundFetchOptions</code></dfn> {
+  <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition" id="ref-for-dictdef-icondefinition">IconDefinition</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="BackgroundFetchOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<IconDefinition> " id="dom-backgroundfetchoptions-icons"><code>icons</code><a class="self-link" href="#dom-backgroundfetchoptions-icons"></a></dfn> = [];
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-2"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="BackgroundFetchOptions" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-backgroundfetchoptions-title"><code>title</code><a class="self-link" href="#dom-backgroundfetchoptions-title"></a></dfn> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long"><span class="kt">long</span></a> <dfn class="nv idl-code" data-default="0" data-dfn-for="BackgroundFetchOptions" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-backgroundfetchoptions-totaldownloadsize"><code>totalDownloadSize</code><a class="self-link" href="#dom-backgroundfetchoptions-totaldownloadsize"></a></dfn> = 0;
 };
 
 // This is taken from https://w3c.github.io/manifest/#icons-member.
 // This definition should probably be moved somewhere more general.
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-icondefinition">IconDefinition</dfn> {
-  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="IconDefinition" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-icondefinition-src">src<a class="self-link" href="#dom-icondefinition-src"></a></dfn>;
-  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="IconDefinition" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-icondefinition-sizes">sizes<a class="self-link" href="#dom-icondefinition-sizes"></a></dfn> = "";
-  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="IconDefinition" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-icondefinition-type">type<a class="self-link" href="#dom-icondefinition-type"></a></dfn> = "";
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-icondefinition"><code>IconDefinition</code></dfn> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-3"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="IconDefinition" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-icondefinition-src"><code>src</code><a class="self-link" href="#dom-icondefinition-src"></a></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-4"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="IconDefinition" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-icondefinition-sizes"><code>sizes</code><a class="self-link" href="#dom-icondefinition-sizes"></a></dfn> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-5"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="IconDefinition" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-icondefinition-type"><code>type</code><a class="self-link" href="#dom-icondefinition-type"></a></dfn> = "";
 };
 </pre>
    <div>
-    <div class="algorithm" data-algorithm="fetch(|tag|, |requests|, |options|)">
-      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchManager" data-dfn-type="method" data-export="" data-lt="fetch(tag, requests, options)|fetch(tag, requests)" id="dom-backgroundfetchmanager-fetch">fetch(<var>tag</var>, <var>requests</var>, <var>options</var>)</dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+    <div class="algorithm" data-algorithm="fetch(|id|, |requests|, |options|)">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchManager" data-dfn-type="method" data-export="" data-lt="fetch(id, requests, options)|fetch(id, requests)" id="dom-backgroundfetchmanager-fetch"><code>fetch(<var>id</var>, <var>requests</var>, <var>options</var>)</code></dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
      <ol>
       <li data-md="">
-       <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">service worker registration</a>.</p>
+       <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object-0">context object</a>'s associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-0">service worker registration</a>.</p>
       <li data-md="">
        <p>TODO.</p>
      </ol>
     </div>
-    <div class="algorithm" data-algorithm="get(|tag|)">
-      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchManager" data-dfn-type="method" data-export="" id="dom-backgroundfetchmanager-get">get(<var>tag</var>)</dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+    <div class="algorithm" data-algorithm="get(|id|)">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchManager" data-dfn-type="method" data-export="" id="dom-backgroundfetchmanager-get"><code>get(<var>id</var>)</code></dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise-0">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel-0">in parallel</a>: 
      <ol>
       <li data-md="">
        <p>TODO</p>
      </ol>
     </div>
-    <div class="algorithm" data-algorithm="getTags()">
-      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchManager" data-dfn-type="method" data-export="" id="dom-backgroundfetchmanager-gettags">getTags()</dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+    <div class="algorithm" data-algorithm="getIdentifiers()">
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchManager" data-dfn-type="method" data-export="" id="dom-backgroundfetchmanager-getidentifiers"><code>getIdentifiers()</code></dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise-1">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel-1">in parallel</a>: 
      <ol>
       <li data-md="">
        <p>TODO</p>
      </ol>
     </div>
    </div>
-   <h3 class="heading settled" data-level="3.3" id="background-fetch-registration"><span class="secno">3.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-3">BackgroundFetchRegistration</a></code></span><a class="self-link" href="#background-fetch-registration"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchregistration">BackgroundFetchRegistration</dfn> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-backgroundfetchregistration-tag">tag<a class="self-link" href="#dom-backgroundfetchregistration-tag"></a></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition" id="ref-for-dictdef-icondefinition-2">IconDefinition</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<IconDefinition>" id="dom-backgroundfetchregistration-icons">icons<a class="self-link" href="#dom-backgroundfetchregistration-icons"></a></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long" id="dom-backgroundfetchregistration-totaldownloadsize">totalDownloadSize<a class="self-link" href="#dom-backgroundfetchregistration-totaldownloadsize"></a></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-backgroundfetchregistration-title">title<a class="self-link" href="#dom-backgroundfetchregistration-title"></a></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchactivefetch" id="ref-for-backgroundfetchactivefetch-1">BackgroundFetchActiveFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<BackgroundFetchActiveFetch>" id="dom-backgroundfetchregistration-activefetches">activeFetches<a class="self-link" href="#dom-backgroundfetchregistration-activefetches"></a></dfn>;
+   <h3 class="heading settled" data-level="3.3" id="background-fetch-registration"><span class="secno">3.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-1">BackgroundFetchRegistration</a></code></span><a class="self-link" href="#background-fetch-registration"></a></h3>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-0">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchregistration"><code>BackgroundFetchRegistration</code></dfn> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-6"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-backgroundfetchregistration-id"><code>id</code><a class="self-link" href="#dom-backgroundfetchregistration-id"></a></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition" id="ref-for-dictdef-icondefinition-0">IconDefinition</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<IconDefinition>" id="dom-backgroundfetchregistration-icons"><code>icons</code><a class="self-link" href="#dom-backgroundfetchregistration-icons"></a></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long-0"><span class="kt">long</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long" id="dom-backgroundfetchregistration-totaldownloadsize"><code>totalDownloadSize</code><a class="self-link" href="#dom-backgroundfetchregistration-totaldownloadsize"></a></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-7"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-backgroundfetchregistration-title"><code>title</code><a class="self-link" href="#dom-backgroundfetchregistration-title"></a></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchactivefetch" id="ref-for-backgroundfetchactivefetch">BackgroundFetchActiveFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<BackgroundFetchActiveFetch>" id="dom-backgroundfetchregistration-activefetches"><code>activeFetches</code><a class="self-link" href="#dom-backgroundfetchregistration-activefetches"></a></dfn>;
 
-  <span class="kt">Promise</span>&lt;<span class="kt">boolean</span>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="method" data-export="" data-lt="abort()" id="dom-backgroundfetchregistration-abort">abort<a class="self-link" href="#dom-backgroundfetchregistration-abort"></a></dfn>();
+  <span class="kt">Promise</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchRegistration" data-dfn-type="method" data-export="" data-lt="abort()" id="dom-backgroundfetchregistration-abort"><code>abort</code><a class="self-link" href="#dom-backgroundfetchregistration-abort"></a></dfn>();
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchfetch">BackgroundFetchFetch</dfn> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFetch" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Request" id="dom-backgroundfetchfetch-request">request<a class="self-link" href="#dom-backgroundfetchfetch-request"></a></dfn>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-1">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchfetch"><code>BackgroundFetchFetch</code></dfn> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request" id="ref-for-request">Request</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFetch" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Request" id="dom-backgroundfetchfetch-request"><code>request</code><a class="self-link" href="#dom-backgroundfetchfetch-request"></a></dfn>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchactivefetch">BackgroundFetchActiveFetch</dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch" id="ref-for-backgroundfetchfetch-1">BackgroundFetchFetch</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response">Response</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchActiveFetch" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Promise<Response>" id="dom-backgroundfetchactivefetch-responseready">responseReady<a class="self-link" href="#dom-backgroundfetchactivefetch-responseready"></a></dfn>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-2">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchactivefetch"><code>BackgroundFetchActiveFetch</code></dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch" id="ref-for-backgroundfetchfetch">BackgroundFetchFetch</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response" id="ref-for-response">Response</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchActiveFetch" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Promise<Response>" id="dom-backgroundfetchactivefetch-responseready"><code>responseReady</code><a class="self-link" href="#dom-backgroundfetchactivefetch-responseready"></a></dfn>;
   // TODO: this will include fetch controller/observer objects
 };
 </pre>
    <div>
-     A <code class="idl"><a data-link-type="idl" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-4">BackgroundFetchRegistration</a></code> has an associated <dfn data-dfn-for="BackgroundFetchRegistration" data-dfn-type="dfn" data-noexport="" id="backgroundfetchregistration-background-fetch">background fetch<a class="self-link" href="#backgroundfetchregistration-background-fetch"></a></dfn>, a <a data-link-type="dfn" href="#background-fetch" id="ref-for-background-fetch-2">background fetch</a>. 
+     A <code class="idl"><a data-link-type="idl" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-2">BackgroundFetchRegistration</a></code> has an associated <dfn data-dfn-for="BackgroundFetchRegistration" data-dfn-type="dfn" data-noexport="" id="backgroundfetchregistration-background-fetch">background fetch<a class="self-link" href="#backgroundfetchregistration-background-fetch"></a></dfn>, a <a data-link-type="dfn" href="#background-fetch" id="ref-for-background-fetch-0">background fetch</a>. 
     <p>TODO</p>
    </div>
    <h3 class="heading settled" data-level="3.4" id="events"><span class="secno">3.4. </span><span class="content">Events</span><a class="self-link" href="#events"></a></h3>
-<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">ServiceWorkerGlobalScope</a> {
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetched">onbackgroundfetched</dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetchfail">onbackgroundfetchfail</dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetchabort">onbackgroundfetchabort</dfn>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetchclick">onbackgroundfetchclick</dfn>;
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a> {
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetched"><code>onbackgroundfetched</code></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-0">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetchfail"><code>onbackgroundfetchfail</code></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-1">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetchabort"><code>onbackgroundfetchabort</code></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-2">EventHandler</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-serviceworkerglobalscope-onbackgroundfetchclick"><code>onbackgroundfetchclick</code></dfn>;
 };
 </pre>
-   <p>The following is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> (and its corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a>) that must be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker">ServiceWorker</a></code> interface:</p>
+   <p>The following is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers">event handler</a> (and its corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type">event handler event type</a>) that must be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes" id="ref-for-event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworker" id="ref-for-serviceworker">ServiceWorker</a></code> interface:</p>
    <table class="data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a>
-      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a>
+      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type" id="ref-for-event-handler-event-type-0">event handler event type</a>
+      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers-0">event handler</a>
       <th>Interface
     <tbody>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetched">backgroundfetched<a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetched"></a></dfn>
-      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetched" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetched-1">onbackgroundfetched</a></code>
-      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent-1">BackgroundFetchedEvent</a></code>
+      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetched"><code>backgroundfetched</code><a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetched"></a></dfn>
+      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetched" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetched">onbackgroundfetched</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent">BackgroundFetchedEvent</a></code>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetchfail">backgroundfetchfail<a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetchfail"></a></dfn>
-      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetchfail" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetchfail-1">onbackgroundfetchfail</a></code>
-      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchfailevent" id="ref-for-backgroundfetchfailevent-1">BackgroundFetchFailEvent</a></code>
+      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetchfail"><code>backgroundfetchfail</code><a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetchfail"></a></dfn>
+      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetchfail" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetchfail">onbackgroundfetchfail</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchfailevent" id="ref-for-backgroundfetchfailevent">BackgroundFetchFailEvent</a></code>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetchabort">backgroundfetchabort<a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetchabort"></a></dfn>
-      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetchabort" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetchabort-1">onbackgroundfetchabort</a></code>
-      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-1">BackgroundFetchEvent</a></code>
+      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetchabort"><code>backgroundfetchabort</code><a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetchabort"></a></dfn>
+      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetchabort" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetchabort">onbackgroundfetchabort</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent">BackgroundFetchEvent</a></code>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetchclick">backgroundfetchclick<a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetchclick"></a></dfn>
-      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetchclick" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetchclick-1">onbackgroundfetchclick</a></code>
-      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchclickevent" id="ref-for-backgroundfetchclickevent-1">BackgroundFetchClickEvent</a></code>
+      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-backgroundfetchclick"><code>backgroundfetchclick</code><a class="self-link" href="#eventdef-serviceworkerglobalscope-backgroundfetchclick"></a></dfn>
+      <td><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onbackgroundfetchclick" id="ref-for-dom-serviceworkerglobalscope-onbackgroundfetchclick">onbackgroundfetchclick</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="#backgroundfetchclickevent" id="ref-for-backgroundfetchclickevent">BackgroundFetchClickEvent</a></code>
    </table>
-   <h4 class="heading settled" data-level="3.4.1" id="background-fetch-event"><span class="secno">3.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-2">BackgroundFetchEvent</a></code></span><a class="self-link" href="#background-fetch-event"></a></h4>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchevent-backgroundfetchevent" id="ref-for-dom-backgroundfetchevent-backgroundfetchevent-1">Constructor</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchEvent/BackgroundFetchEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchevent-backgroundfetchevent-type-init-type">type<a class="self-link" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-1">BackgroundFetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchEvent/BackgroundFetchEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchevent-backgroundfetchevent-type-init-init">init<a class="self-link" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchevent">BackgroundFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#extendableevent">ExtendableEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchevent-tag" id="ref-for-dom-backgroundfetchevent-tag-1">tag</a>;
+   <h4 class="heading settled" data-level="3.4.1" id="background-fetch-event"><span class="secno">3.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-0">BackgroundFetchEvent</a></code></span><a class="self-link" href="#background-fetch-event"></a></h4>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchevent-backgroundfetchevent" id="ref-for-dom-backgroundfetchevent-backgroundfetchevent">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-8"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchEvent/BackgroundFetchEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchevent-backgroundfetchevent-type-init-type"><code>type</code><a class="self-link" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit">BackgroundFetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchEvent/BackgroundFetchEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchevent-backgroundfetchevent-type-init-init"><code>init</code><a class="self-link" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-3">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchevent"><code>BackgroundFetchEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent">ExtendableEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-9"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchevent-id" id="ref-for-dom-backgroundfetchevent-id">id</a>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetcheventinit">BackgroundFetchEventInit</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">ExtendableEventInit</a> {
-  <span class="kt">required</span> <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-backgroundfetcheventinit-tag">tag<a class="self-link" href="#dom-backgroundfetcheventinit-tag"></a></dfn>;
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetcheventinit"><code>BackgroundFetchEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit">ExtendableEventInit</a> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-10"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-backgroundfetcheventinit-id"><code>id</code><a class="self-link" href="#dom-backgroundfetcheventinit-id"></a></dfn>;
 };
 </pre>
    <div>
-     A <code class="idl"><a data-link-type="idl" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-3">BackgroundFetchEvent</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="BackgroundFetchEvent" data-dfn-type="dfn" data-noexport="" id="backgroundfetchevent-tag">tag</dfn>, a DOMString. 
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchEvent" data-dfn-type="attribute" data-export="" id="dom-backgroundfetchevent-tag">tag</dfn> attribute must return the <a data-link-type="dfn" href="#backgroundfetchevent-tag" id="ref-for-backgroundfetchevent-tag-1">tag</a>.</p>
+     A <code class="idl"><a data-link-type="idl" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-1">BackgroundFetchEvent</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="BackgroundFetchEvent" data-dfn-type="dfn" data-noexport="" id="backgroundfetchevent-id">id</dfn>, a DOMString. 
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchEvent" data-dfn-type="attribute" data-export="" id="dom-backgroundfetchevent-id"><code>id</code></dfn> attribute must return the <a data-link-type="dfn" href="#backgroundfetchevent-id" id="ref-for-backgroundfetchevent-id">id</a>.</p>
     <p>TODO</p>
    </div>
    <div class="algorithm" data-algorithm="BackgroundFetchEvent(|type|, |init|)">
-     The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchEvent" data-dfn-type="constructor" data-export="" id="dom-backgroundfetchevent-backgroundfetchevent">BackgroundFetchEvent(<var>type</var>, <var>init</var>)</dfn> constructor, when invoked, must run these steps: 
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchEvent" data-dfn-type="constructor" data-export="" id="dom-backgroundfetchevent-backgroundfetchevent"><code>BackgroundFetchEvent(<var>type</var>, <var>init</var>)</code></dfn> constructor, when invoked, must run these steps: 
     <ol>
      <li data-md="">
       <p>TODO</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.4.2" id="background-fetch-end-event"><span class="secno">3.4.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent-2">BackgroundFetchedEvent</a></code></span><a class="self-link" href="#background-fetch-end-event"></a></h4>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchedevent-backgroundfetchedevent" id="ref-for-dom-backgroundfetchedevent-backgroundfetchedevent-1">Constructor</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent/BackgroundFetchedEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchedevent-backgroundfetchedevent-type-init-type">type<a class="self-link" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-1">BackgroundFetchedEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent/BackgroundFetchedEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchedevent-backgroundfetchedevent-type-init-init">init<a class="self-link" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchedevent">BackgroundFetchedEvent</dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-4">BackgroundFetchEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-1">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" id="dom-backgroundfetchedevent-fetches">fetches<a class="self-link" href="#dom-backgroundfetchedevent-fetches"></a></dfn>;
+   <h4 class="heading settled" data-level="3.4.2" id="background-fetch-end-event"><span class="secno">3.4.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent-0">BackgroundFetchedEvent</a></code></span><a class="self-link" href="#background-fetch-end-event"></a></h4>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchedevent-backgroundfetchedevent" id="ref-for-dom-backgroundfetchedevent-backgroundfetchedevent">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-11"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent/BackgroundFetchedEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchedevent-backgroundfetchedevent-type-init-type"><code>type</code><a class="self-link" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent/BackgroundFetchedEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchedevent-backgroundfetchedevent-type-init-init"><code>init</code><a class="self-link" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-4">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchedevent"><code>BackgroundFetchedEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-2">BackgroundFetchEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" id="dom-backgroundfetchedevent-fetches"><code>fetches</code><a class="self-link" href="#dom-backgroundfetchedevent-fetches"></a></dfn>;
 
-  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchedevent-updateui" id="ref-for-dom-backgroundfetchedevent-updateui-1">updateUI</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent/updateUI(title)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchedevent-updateui-title-title">title<a class="self-link" href="#dom-backgroundfetchedevent-updateui-title-title"></a></dfn>);
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchedevent-updateui" id="ref-for-dom-backgroundfetchedevent-updateui">updateUI</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-12"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEvent/updateUI(title)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchedevent-updateui-title-title"><code>title</code><a class="self-link" href="#dom-backgroundfetchedevent-updateui-title-title"></a></dfn>);
 };
 
-<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-2">BackgroundFetchEventInit</a> {
-  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-2">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<BackgroundFetchSettledFetch> " id="dom-backgroundfetchedeventinit-fetches">fetches<a class="self-link" href="#dom-backgroundfetchedeventinit-fetches"></a></dfn>;
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchedeventinit"><code>BackgroundFetchedEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-0">BackgroundFetchEventInit</a> {
+  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-0">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchedEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<BackgroundFetchSettledFetch> " id="dom-backgroundfetchedeventinit-fetches"><code>fetches</code><a class="self-link" href="#dom-backgroundfetchedeventinit-fetches"></a></dfn>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchsettledfetch">BackgroundFetchSettledFetch</dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch" id="ref-for-backgroundfetchfetch-2">BackgroundFetchFetch</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response">Response</a>? <dfn class="nv idl-code" data-dfn-for="BackgroundFetchSettledFetch" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Response?" id="dom-backgroundfetchsettledfetch-response">response<a class="self-link" href="#dom-backgroundfetchsettledfetch-response"></a></dfn>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-5">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchsettledfetch"><code>BackgroundFetchSettledFetch</code></dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch" id="ref-for-backgroundfetchfetch-0">BackgroundFetchFetch</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response" id="ref-for-response-0">Response</a>? <dfn class="nv idl-code" data-dfn-for="BackgroundFetchSettledFetch" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Response?" id="dom-backgroundfetchsettledfetch-response"><code>response</code><a class="self-link" href="#dom-backgroundfetchsettledfetch-response"></a></dfn>;
 };
 </pre>
    <div>
-     The <dfn class="idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="attribute" data-export="" id="dom-backgroundfetchedevent-completefetches">completeFetches<a class="self-link" href="#dom-backgroundfetchedevent-completefetches"></a></dfn> attribute must return TODO. 
+     The <dfn class="idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="attribute" data-export="" id="dom-backgroundfetchedevent-completefetches"><code>completeFetches</code><a class="self-link" href="#dom-backgroundfetchedevent-completefetches"></a></dfn> attribute must return TODO. 
     <div class="algorithm" data-algorithm="updateUI(|title|)">
-      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="method" data-export="" id="dom-backgroundfetchedevent-updateui">updateUI(<var>title</var>)</dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="method" data-export="" id="dom-backgroundfetchedevent-updateui"><code>updateUI(<var>title</var>)</code></dfn> method, when invoked, must return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise-2">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel-2">in parallel</a>: 
      <ol>
       <li data-md="">
        <p>TODO</p>
@@ -1689,33 +1690,33 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </div>
    </div>
    <div class="algorithm" data-algorithm="BackgroundFetchedEvent(|type|, |init|)">
-     The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="constructor" data-export="" id="dom-backgroundfetchedevent-backgroundfetchedevent">BackgroundFetchedEvent(<var>type</var>, <var>init</var>)</dfn> constructor, when invoked, must run these steps: 
+     The <dfn class="dfn-paneled idl-code" data-dfn-for="BackgroundFetchedEvent" data-dfn-type="constructor" data-export="" id="dom-backgroundfetchedevent-backgroundfetchedevent"><code>BackgroundFetchedEvent(<var>type</var>, <var>init</var>)</code></dfn> constructor, when invoked, must run these steps: 
     <ol>
      <li data-md="">
       <p>TODO</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.4.3" id="background-fetch-fail-event"><span class="secno">3.4.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchfailevent" id="ref-for-backgroundfetchfailevent-2">BackgroundFetchFailEvent</a></code></span><a class="self-link" href="#background-fetch-fail-event"></a></h4>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent" data-dfn-type="constructor" data-export="" data-lt="BackgroundFetchFailEvent(type, init)" id="dom-backgroundfetchfailevent-backgroundfetchfailevent">Constructor<a class="self-link" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent/BackgroundFetchFailEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-type">type<a class="self-link" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-2">BackgroundFetchedEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent/BackgroundFetchFailEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-init">init<a class="self-link" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchfailevent">BackgroundFetchFailEvent</dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent-3">BackgroundFetchedEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-3">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" id="dom-backgroundfetchfailevent-fetches">fetches<a class="self-link" href="#dom-backgroundfetchfailevent-fetches"></a></dfn>;
+   <h4 class="heading settled" data-level="3.4.3" id="background-fetch-fail-event"><span class="secno">3.4.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchfailevent" id="ref-for-backgroundfetchfailevent-0">BackgroundFetchFailEvent</a></code></span><a class="self-link" href="#background-fetch-fail-event"></a></h4>
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent" data-dfn-type="constructor" data-export="" data-lt="BackgroundFetchFailEvent(type, init)" id="dom-backgroundfetchfailevent-backgroundfetchfailevent"><code>Constructor</code><a class="self-link" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-13"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent/BackgroundFetchFailEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-type"><code>type</code><a class="self-link" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-0">BackgroundFetchedEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent/BackgroundFetchFailEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-init"><code>init</code><a class="self-link" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-6">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchfailevent"><code>BackgroundFetchFailEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent-1">BackgroundFetchedEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-1">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" id="dom-backgroundfetchfailevent-fetches"><code>fetches</code><a class="self-link" href="#dom-backgroundfetchfailevent-fetches"></a></dfn>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchfaileventinit">BackgroundFetchFailEventInit<a class="self-link" href="#dictdef-backgroundfetchfaileventinit"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-3">BackgroundFetchedEventInit</a> {
-  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-4">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<BackgroundFetchSettledFetch> " id="dom-backgroundfetchfaileventinit-fetches">fetches<a class="self-link" href="#dom-backgroundfetchfaileventinit-fetches"></a></dfn>;
+<span class="kt">dictionary</span> <dfn class="nv idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchfaileventinit"><code>BackgroundFetchFailEventInit</code><a class="self-link" href="#dictdef-backgroundfetchfaileventinit"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-1">BackgroundFetchedEventInit</a> {
+  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-2">BackgroundFetchSettledFetch</a>> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchFailEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<BackgroundFetchSettledFetch> " id="dom-backgroundfetchfaileventinit-fetches"><code>fetches</code><a class="self-link" href="#dom-backgroundfetchfaileventinit-fetches"></a></dfn>;
 };
 </pre>
-   <h4 class="heading settled" data-level="3.4.4" id="background-fetch-click-event"><span class="secno">3.4.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchclickevent" id="ref-for-backgroundfetchclickevent-2">BackgroundFetchClickEvent</a></code></span><a class="self-link" href="#background-fetch-click-event"></a></h4>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent" data-dfn-type="constructor" data-export="" data-lt="BackgroundFetchClickEvent(type, init)" id="dom-backgroundfetchclickevent-backgroundfetchclickevent">Constructor<a class="self-link" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent/BackgroundFetchClickEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-type">type<a class="self-link" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-4">BackgroundFetchedEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent/BackgroundFetchClickEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-init">init<a class="self-link" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchclickevent">BackgroundFetchClickEvent</dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-5">BackgroundFetchEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate" id="ref-for-enumdef-backgroundfetchstate-1">BackgroundFetchState</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="BackgroundFetchState" id="dom-backgroundfetchclickevent-state">state<a class="self-link" href="#dom-backgroundfetchclickevent-state"></a></dfn>;
+   <h4 class="heading settled" data-level="3.4.4" id="background-fetch-click-event"><span class="secno">3.4.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#backgroundfetchclickevent" id="ref-for-backgroundfetchclickevent-0">BackgroundFetchClickEvent</a></code></span><a class="self-link" href="#background-fetch-click-event"></a></h4>
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent" data-dfn-type="constructor" data-export="" data-lt="BackgroundFetchClickEvent(type, init)" id="dom-backgroundfetchclickevent-backgroundfetchclickevent"><code>Constructor</code><a class="self-link" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-14"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent/BackgroundFetchClickEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-type"><code>type</code><a class="self-link" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-2">BackgroundFetchedEventInit</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent/BackgroundFetchClickEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-init"><code>init</code><a class="self-link" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-init"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-7">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="backgroundfetchclickevent"><code>BackgroundFetchClickEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-3">BackgroundFetchEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate" id="ref-for-enumdef-backgroundfetchstate">BackgroundFetchState</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="BackgroundFetchState" id="dom-backgroundfetchclickevent-state"><code>state</code><a class="self-link" href="#dom-backgroundfetchclickevent-state"></a></dfn>;
 };
 
-<span class="kt">dictionary</span> <dfn class="nv idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchclickeventinit">BackgroundFetchClickEventInit<a class="self-link" href="#dictdef-backgroundfetchclickeventinit"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-3">BackgroundFetchEventInit</a> {
-  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate" id="ref-for-enumdef-backgroundfetchstate-2">BackgroundFetchState</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEventInit" data-dfn-type="dict-member" data-export="" data-type="BackgroundFetchState " id="dom-backgroundfetchclickeventinit-state">state<a class="self-link" href="#dom-backgroundfetchclickeventinit-state"></a></dfn>;
+<span class="kt">dictionary</span> <dfn class="nv idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-backgroundfetchclickeventinit"><code>BackgroundFetchClickEventInit</code><a class="self-link" href="#dictdef-backgroundfetchclickeventinit"></a></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-1">BackgroundFetchEventInit</a> {
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate" id="ref-for-enumdef-backgroundfetchstate-0">BackgroundFetchState</a> <dfn class="nv idl-code" data-dfn-for="BackgroundFetchClickEventInit" data-dfn-type="dict-member" data-export="" data-type="BackgroundFetchState " id="dom-backgroundfetchclickeventinit-state"><code>state</code><a class="self-link" href="#dom-backgroundfetchclickeventinit-state"></a></dfn>;
 };
 
-<span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-backgroundfetchstate">BackgroundFetchState</dfn> { <dfn class="s idl-code" data-dfn-for="BackgroundFetchState" data-dfn-type="enum-value" data-export="" data-lt="&quot;pending&quot;|pending" id="dom-backgroundfetchstate-pending">"pending"<a class="self-link" href="#dom-backgroundfetchstate-pending"></a></dfn>, <dfn class="s idl-code" data-dfn-for="BackgroundFetchState" data-dfn-type="enum-value" data-export="" data-lt="&quot;succeeded&quot;|succeeded" id="dom-backgroundfetchstate-succeeded">"succeeded"<a class="self-link" href="#dom-backgroundfetchstate-succeeded"></a></dfn>, <dfn class="s idl-code" data-dfn-for="BackgroundFetchState" data-dfn-type="enum-value" data-export="" data-lt="&quot;failed&quot;|failed" id="dom-backgroundfetchstate-failed">"failed"<a class="self-link" href="#dom-backgroundfetchstate-failed"></a></dfn> };
+<span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-backgroundfetchstate"><code>BackgroundFetchState</code></dfn> { <dfn class="s idl-code" data-dfn-for="BackgroundFetchState" data-dfn-type="enum-value" data-export="" data-lt="&quot;pending&quot;|pending" id="dom-backgroundfetchstate-pending"><code>"pending"</code><a class="self-link" href="#dom-backgroundfetchstate-pending"></a></dfn>, <dfn class="s idl-code" data-dfn-for="BackgroundFetchState" data-dfn-type="enum-value" data-export="" data-lt="&quot;succeeded&quot;|succeeded" id="dom-backgroundfetchstate-succeeded"><code>"succeeded"</code><a class="self-link" href="#dom-backgroundfetchstate-succeeded"></a></dfn>, <dfn class="s idl-code" data-dfn-for="BackgroundFetchState" data-dfn-type="enum-value" data-export="" data-lt="&quot;failed&quot;|failed" id="dom-backgroundfetchstate-failed"><code>"failed"</code><a class="self-link" href="#dom-backgroundfetchstate-failed"></a></dfn> };
 </pre>
   </main>
   <div data-fill-with="conformance">
@@ -1730,7 +1731,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
             except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
    <p> Examples in this specification are introduced with the words “for example”
             or are set apart from the normative text with <code>class="example"</code>, like this: </p>
-   <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a> This is an example of an informative example. </div>
+   <div class="example" id="example-example"><a class="self-link" href="#example-example"></a> This is an example of an informative example. </div>
    <p> Informative notes begin with the word “Note”
             and are set apart from the normative text with <code>class="note"</code>, like this: </p>
    <p class="note" role="note"> Note, this is an informative note. </p>
@@ -1910,16 +1911,25 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li><a href="#dom-backgroundfetchfailevent-fetches">attribute for BackgroundFetchFailEvent</a><span>, in §3.4.3</span>
      <li><a href="#dom-backgroundfetchfaileventinit-fetches">dict-member for BackgroundFetchFailEventInit</a><span>, in §3.4.3</span>
     </ul>
-   <li><a href="#dom-backgroundfetchmanager-fetch">fetch(tag, requests)</a><span>, in §3.2</span>
-   <li><a href="#dom-backgroundfetchmanager-fetch">fetch(tag, requests, options)</a><span>, in §3.2</span>
-   <li><a href="#dom-backgroundfetchmanager-get">get(tag)</a><span>, in §3.2</span>
-   <li><a href="#dom-backgroundfetchmanager-gettags">getTags()</a><span>, in §3.2</span>
+   <li><a href="#dom-backgroundfetchmanager-fetch">fetch(id, requests)</a><span>, in §3.2</span>
+   <li><a href="#dom-backgroundfetchmanager-fetch">fetch(id, requests, options)</a><span>, in §3.2</span>
+   <li><a href="#dom-backgroundfetchmanager-get">get(id)</a><span>, in §3.2</span>
+   <li><a href="#dom-backgroundfetchmanager-getidentifiers">getIdentifiers()</a><span>, in §3.2</span>
    <li><a href="#dictdef-icondefinition">IconDefinition</a><span>, in §3.2</span>
    <li>
     icons
     <ul>
      <li><a href="#dom-backgroundfetchoptions-icons">dict-member for BackgroundFetchOptions</a><span>, in §3.2</span>
      <li><a href="#dom-backgroundfetchregistration-icons">attribute for BackgroundFetchRegistration</a><span>, in §3.3</span>
+    </ul>
+   <li>
+    id
+    <ul>
+     <li><a href="#background-fetch-id">dfn for background fetch</a><span>, in §2</span>
+     <li><a href="#dom-backgroundfetchregistration-id">attribute for BackgroundFetchRegistration</a><span>, in §3.3</span>
+     <li><a href="#dom-backgroundfetcheventinit-id">dict-member for BackgroundFetchEventInit</a><span>, in §3.4.1</span>
+     <li><a href="#backgroundfetchevent-id">dfn for BackgroundFetchEvent</a><span>, in §3.4.1</span>
+     <li><a href="#dom-backgroundfetchevent-id">attribute for BackgroundFetchEvent</a><span>, in §3.4.1</span>
     </ul>
    <li><a href="#service-worker-registration-list-of-active-background-fetches">list of active background fetches</a><span>, in §2</span>
    <li><a href="#dom-serviceworkerglobalscope-onbackgroundfetchabort">onbackgroundfetchabort</a><span>, in §3.4</span>
@@ -1942,15 +1952,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#dom-backgroundfetchstate-succeeded">"succeeded"</a><span>, in §3.4.4</span>
    <li><a href="#dom-backgroundfetchstate-succeeded">succeeded</a><span>, in §3.4.4</span>
    <li>
-    tag
-    <ul>
-     <li><a href="#background-fetch-tag">dfn for background fetch</a><span>, in §2</span>
-     <li><a href="#dom-backgroundfetchregistration-tag">attribute for BackgroundFetchRegistration</a><span>, in §3.3</span>
-     <li><a href="#dom-backgroundfetcheventinit-tag">dict-member for BackgroundFetchEventInit</a><span>, in §3.4.1</span>
-     <li><a href="#backgroundfetchevent-tag">dfn for BackgroundFetchEvent</a><span>, in §3.4.1</span>
-     <li><a href="#dom-backgroundfetchevent-tag">attribute for BackgroundFetchEvent</a><span>, in §3.4.1</span>
-    </ul>
-   <li>
     title
     <ul>
      <li><a href="#dom-backgroundfetchoptions-title">dict-member for BackgroundFetchOptions</a><span>, in §3.2</span>
@@ -1968,7 +1969,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
     </ul>
@@ -2014,12 +2015,17 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-long">long</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]
@@ -2031,297 +2037,295 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-service-workers-1">[SERVICE-WORKERS-1]
-   <dd>Alex Russell; et al. <a href="https://w3c.github.io/ServiceWorker/">Service Workers 1</a>. URL: <a href="https://w3c.github.io/ServiceWorker/">https://w3c.github.io/ServiceWorker/</a>
+   <dd>Alex Russell; et al. <a href="https://www.w3.org/TR/service-workers-1/">Service Workers 1</a>. URL: <a href="https://www.w3.org/TR/service-workers-1/">https://www.w3.org/TR/service-workers-1/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
-   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
-   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">ServiceWorkerRegistration</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#backgroundfetchmanager">BackgroundFetchManager</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="BackgroundFetchManager" href="#dom-serviceworkerregistration-backgroundfetch">backgroundFetch</a>;
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration-0-0">ServiceWorkerRegistration</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#backgroundfetchmanager" id="ref-for-backgroundfetchmanager-0-0">BackgroundFetchManager</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="BackgroundFetchManager" href="#dom-serviceworkerregistration-backgroundfetch" id="ref-for-dom-serviceworkerregistration-backgroundfetch-0">backgroundFetch</a>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchmanager">BackgroundFetchManager</a> {
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration">BackgroundFetchRegistration</a>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-fetch">fetch</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchmanager-fetch-tag-requests-options-tag">tag</a>, (<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo">RequestInfo</a> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo">RequestInfo</a>>) <a class="nv" href="#dom-backgroundfetchmanager-fetch-tag-requests-options-requests">requests</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchoptions">BackgroundFetchOptions</a> <a class="nv" href="#dom-backgroundfetchmanager-fetch-tag-requests-options-options">options</a>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration">BackgroundFetchRegistration</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-get">get</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchmanager-get-tag-tag">tag</a>);
-  <span class="kt">Promise</span>&lt;<span class="kt">FrozenArray</span>&lt;<span class="kt">DOMString</span>>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-gettags">getTags</a>();
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-0-0">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchmanager"><code>BackgroundFetchManager</code></a> {
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-0-0">BackgroundFetchRegistration</a>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-fetch" id="ref-for-dom-backgroundfetchmanager-fetch-0">fetch</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-0-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchmanager-fetch-id-requests-options-id"><code>id</code></a>, (<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo" id="ref-for-requestinfo-0-0">RequestInfo</a> <span class="kt">or</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#requestinfo" id="ref-for-requestinfo-0-0">RequestInfo</a>>) <a class="nv" href="#dom-backgroundfetchmanager-fetch-id-requests-options-requests"><code>requests</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchoptions" id="ref-for-dictdef-backgroundfetchoptions-0">BackgroundFetchOptions</a> <a class="nv" href="#dom-backgroundfetchmanager-fetch-id-requests-options-options"><code>options</code></a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchregistration" id="ref-for-backgroundfetchregistration-0-0">BackgroundFetchRegistration</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-get" id="ref-for-dom-backgroundfetchmanager-get-0">get</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-0-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchmanager-get-id-id"><code>id</code></a>);
+  <span class="kt">Promise</span>&lt;<span class="kt">FrozenArray</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-1-0"><span class="kt">DOMString</span></a>>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchmanager-getidentifiers" id="ref-for-dom-backgroundfetchmanager-getidentifiers-0">getIdentifiers</a>();
   // TODO: in future this should become an async iterator for BackgroundFetchRegistration objects
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchoptions">BackgroundFetchOptions</a> {
-  <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition">IconDefinition</a>> <a class="nv" data-default="None" data-type="sequence<IconDefinition> " href="#dom-backgroundfetchoptions-icons">icons</a> = [];
-  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-backgroundfetchoptions-title">title</a> = "";
-  <span class="kt">long</span> <a class="nv" data-default="0" data-type="long " href="#dom-backgroundfetchoptions-totaldownloadsize">totalDownloadSize</a> = 0;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchoptions"><code>BackgroundFetchOptions</code></a> {
+  <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition" id="ref-for-dictdef-icondefinition-0-0">IconDefinition</a>> <a class="nv" data-default="None" data-type="sequence<IconDefinition> " href="#dom-backgroundfetchoptions-icons"><code>icons</code></a> = [];
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-2-0"><span class="kt">DOMString</span></a> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-backgroundfetchoptions-title"><code>title</code></a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long-0-0"><span class="kt">long</span></a> <a class="nv" data-default="0" data-type="long " href="#dom-backgroundfetchoptions-totaldownloadsize"><code>totalDownloadSize</code></a> = 0;
 };
 
 // This is taken from https://w3c.github.io/manifest/#icons-member.
 // This definition should probably be moved somewhere more general.
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-icondefinition">IconDefinition</a> {
-  <span class="kt">DOMString</span> <a class="nv" data-type="DOMString " href="#dom-icondefinition-src">src</a>;
-  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-icondefinition-sizes">sizes</a> = "";
-  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-icondefinition-type">type</a> = "";
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-icondefinition"><code>IconDefinition</code></a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-3-0"><span class="kt">DOMString</span></a> <a class="nv" data-type="DOMString " href="#dom-icondefinition-src"><code>src</code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-4-0"><span class="kt">DOMString</span></a> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-icondefinition-sizes"><code>sizes</code></a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-5-0"><span class="kt">DOMString</span></a> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-icondefinition-type"><code>type</code></a> = "";
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchregistration">BackgroundFetchRegistration</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchregistration-tag">tag</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition">IconDefinition</a>> <a class="nv" data-readonly="" data-type="FrozenArray<IconDefinition>" href="#dom-backgroundfetchregistration-icons">icons</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="long" href="#dom-backgroundfetchregistration-totaldownloadsize">totalDownloadSize</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchregistration-title">title</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchactivefetch">BackgroundFetchActiveFetch</a>> <a class="nv" data-readonly="" data-type="FrozenArray<BackgroundFetchActiveFetch>" href="#dom-backgroundfetchregistration-activefetches">activeFetches</a>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-0-0">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchregistration"><code>BackgroundFetchRegistration</code></a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-6-0"><span class="kt">DOMString</span></a> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchregistration-id"><code>id</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#dictdef-icondefinition" id="ref-for-dictdef-icondefinition-0-0">IconDefinition</a>> <a class="nv" data-readonly="" data-type="FrozenArray<IconDefinition>" href="#dom-backgroundfetchregistration-icons"><code>icons</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long-0-0"><span class="kt">long</span></a> <a class="nv" data-readonly="" data-type="long" href="#dom-backgroundfetchregistration-totaldownloadsize"><code>totalDownloadSize</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-7-0"><span class="kt">DOMString</span></a> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchregistration-title"><code>title</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchactivefetch" id="ref-for-backgroundfetchactivefetch-0">BackgroundFetchActiveFetch</a>> <a class="nv" data-readonly="" data-type="FrozenArray<BackgroundFetchActiveFetch>" href="#dom-backgroundfetchregistration-activefetches"><code>activeFetches</code></a>;
 
-  <span class="kt">Promise</span>&lt;<span class="kt">boolean</span>> <a class="nv" href="#dom-backgroundfetchregistration-abort">abort</a>();
+  <span class="kt">Promise</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean-0"><span class="kt">boolean</span></a>> <a class="nv" href="#dom-backgroundfetchregistration-abort"><code>abort</code></a>();
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchfetch">BackgroundFetchFetch</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv" data-readonly="" data-type="Request" href="#dom-backgroundfetchfetch-request">request</a>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-1-0">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchfetch"><code>BackgroundFetchFetch</code></a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request" id="ref-for-request-0">Request</a> <a class="nv" data-readonly="" data-type="Request" href="#dom-backgroundfetchfetch-request"><code>request</code></a>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchactivefetch">BackgroundFetchActiveFetch</a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch">BackgroundFetchFetch</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response">Response</a>> <a class="nv" data-readonly="" data-type="Promise<Response>" href="#dom-backgroundfetchactivefetch-responseready">responseReady</a>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-2-0">Exposed</a>=(<span class="n">Window</span>,<span class="n">Worker</span>)]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchactivefetch"><code>BackgroundFetchActiveFetch</code></a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch" id="ref-for-backgroundfetchfetch-0-0">BackgroundFetchFetch</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response" id="ref-for-response-0-0">Response</a>> <a class="nv" data-readonly="" data-type="Promise<Response>" href="#dom-backgroundfetchactivefetch-responseready"><code>responseReady</code></a>;
   // TODO: this will include fetch controller/observer objects
 };
 
-<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">ServiceWorkerGlobalScope</a> {
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetched">onbackgroundfetched</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetchfail">onbackgroundfetchfail</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetchabort">onbackgroundfetchabort</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetchclick">onbackgroundfetchclick</a>;
+<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-0">ServiceWorkerGlobalScope</a> {
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-0-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetched"><code>onbackgroundfetched</code></a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-0-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetchfail"><code>onbackgroundfetchfail</code></a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-1-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetchabort"><code>onbackgroundfetchabort</code></a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler-2-0">EventHandler</a> <a class="nv" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onbackgroundfetchclick"><code>onbackgroundfetchclick</code></a>;
 };
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchevent-backgroundfetchevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-type">type</a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit">BackgroundFetchEventInit</a> <a class="nv" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-init">init</a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchevent">BackgroundFetchEvent</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#extendableevent">ExtendableEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchevent-tag">tag</a>;
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchevent-backgroundfetchevent" id="ref-for-dom-backgroundfetchevent-backgroundfetchevent-0">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-8-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-0-0">BackgroundFetchEventInit</a> <a class="nv" href="#dom-backgroundfetchevent-backgroundfetchevent-type-init-init"><code>init</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-3-0">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchevent"><code>BackgroundFetchEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent-0">ExtendableEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-9-0"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-backgroundfetchevent-id" id="ref-for-dom-backgroundfetchevent-id-0">id</a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetcheventinit">BackgroundFetchEventInit</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">ExtendableEventInit</a> {
-  <span class="kt">required</span> <span class="kt">DOMString</span> <a class="nv" data-type="DOMString " href="#dom-backgroundfetcheventinit-tag">tag</a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetcheventinit"><code>BackgroundFetchEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit-0">ExtendableEventInit</a> {
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-10-0"><span class="kt">DOMString</span></a> <a class="nv" data-type="DOMString " href="#dom-backgroundfetcheventinit-id"><code>id</code></a>;
 };
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchedevent-backgroundfetchedevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-type">type</a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</a> <a class="nv" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-init">init</a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchedevent">BackgroundFetchedEvent</a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent">BackgroundFetchEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch">BackgroundFetchSettledFetch</a>> <a class="nv" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" href="#dom-backgroundfetchedevent-fetches">fetches</a>;
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-backgroundfetchedevent-backgroundfetchedevent" id="ref-for-dom-backgroundfetchedevent-backgroundfetchedevent-0">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-11-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-0-0">BackgroundFetchedEventInit</a> <a class="nv" href="#dom-backgroundfetchedevent-backgroundfetchedevent-type-init-init"><code>init</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-4-0">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchedevent"><code>BackgroundFetchedEvent</code></a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-2-0">BackgroundFetchEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-0-0">BackgroundFetchSettledFetch</a>> <a class="nv" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" href="#dom-backgroundfetchedevent-fetches"><code>fetches</code></a>;
 
-  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchedevent-updateui">updateUI</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchedevent-updateui-title-title">title</a>);
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-backgroundfetchedevent-updateui" id="ref-for-dom-backgroundfetchedevent-updateui-0">updateUI</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-12-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchedevent-updateui-title-title"><code>title</code></a>);
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit">BackgroundFetchEventInit</a> {
-  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch">BackgroundFetchSettledFetch</a>> <a class="nv" data-type="sequence<BackgroundFetchSettledFetch> " href="#dom-backgroundfetchedeventinit-fetches">fetches</a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchedeventinit"><code>BackgroundFetchedEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-0-0">BackgroundFetchEventInit</a> {
+  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-0-0">BackgroundFetchSettledFetch</a>> <a class="nv" data-type="sequence<BackgroundFetchSettledFetch> " href="#dom-backgroundfetchedeventinit-fetches"><code>fetches</code></a>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchsettledfetch">BackgroundFetchSettledFetch</a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch">BackgroundFetchFetch</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response">Response</a>? <a class="nv" data-readonly="" data-type="Response?" href="#dom-backgroundfetchsettledfetch-response">response</a>;
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-5-0">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchsettledfetch"><code>BackgroundFetchSettledFetch</code></a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchfetch" id="ref-for-backgroundfetchfetch-0-0">BackgroundFetchFetch</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#response" id="ref-for-response-0-0">Response</a>? <a class="nv" data-readonly="" data-type="Response?" href="#dom-backgroundfetchsettledfetch-response"><code>response</code></a>;
 };
 
-[<a class="nv" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-type">type</a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</a> <a class="nv" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-init">init</a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchfailevent">BackgroundFetchFailEvent</a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchedevent">BackgroundFetchedEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch">BackgroundFetchSettledFetch</a>> <a class="nv" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" href="#dom-backgroundfetchfailevent-fetches">fetches</a>;
+[<a class="nv" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-13-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-0-0">BackgroundFetchedEventInit</a> <a class="nv" href="#dom-backgroundfetchfailevent-backgroundfetchfailevent-type-init-init"><code>init</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-6-0">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchfailevent"><code>BackgroundFetchFailEvent</code></a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchedevent" id="ref-for-backgroundfetchedevent-1-0">BackgroundFetchedEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">FrozenArray</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-1-0">BackgroundFetchSettledFetch</a>> <a class="nv" data-readonly="" data-type="FrozenArray<BackgroundFetchSettledFetch>" href="#dom-backgroundfetchfailevent-fetches"><code>fetches</code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchfaileventinit">BackgroundFetchFailEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</a> {
-  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch">BackgroundFetchSettledFetch</a>> <a class="nv" data-type="sequence<BackgroundFetchSettledFetch> " href="#dom-backgroundfetchfaileventinit-fetches">fetches</a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchfaileventinit"><code>BackgroundFetchFailEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-1-0">BackgroundFetchedEventInit</a> {
+  <span class="kt">required</span> <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#backgroundfetchsettledfetch" id="ref-for-backgroundfetchsettledfetch-2-0">BackgroundFetchSettledFetch</a>> <a class="nv" data-type="sequence<BackgroundFetchSettledFetch> " href="#dom-backgroundfetchfaileventinit-fetches"><code>fetches</code></a>;
 };
 
-[<a class="nv" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-type">type</a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit">BackgroundFetchedEventInit</a> <a class="nv" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-init">init</a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <a class="nv" href="#backgroundfetchclickevent">BackgroundFetchClickEvent</a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent">BackgroundFetchEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate">BackgroundFetchState</a> <a class="nv" data-readonly="" data-type="BackgroundFetchState" href="#dom-backgroundfetchclickevent-state">state</a>;
+[<a class="nv" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString-14-0"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-type"><code>type</code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetchedeventinit" id="ref-for-dictdef-backgroundfetchedeventinit-2-0">BackgroundFetchedEventInit</a> <a class="nv" href="#dom-backgroundfetchclickevent-backgroundfetchclickevent-type-init-init"><code>init</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed-7-0">Exposed</a>=<span class="n">ServiceWorker</span>]
+<span class="kt">interface</span> <a class="nv" href="#backgroundfetchclickevent"><code>BackgroundFetchClickEvent</code></a> : <a class="n" data-link-type="idl-name" href="#backgroundfetchevent" id="ref-for-backgroundfetchevent-3-0">BackgroundFetchEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate" id="ref-for-enumdef-backgroundfetchstate-0-0">BackgroundFetchState</a> <a class="nv" data-readonly="" data-type="BackgroundFetchState" href="#dom-backgroundfetchclickevent-state"><code>state</code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchclickeventinit">BackgroundFetchClickEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit">BackgroundFetchEventInit</a> {
-  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate">BackgroundFetchState</a> <a class="nv" data-type="BackgroundFetchState " href="#dom-backgroundfetchclickeventinit-state">state</a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-backgroundfetchclickeventinit"><code>BackgroundFetchClickEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-backgroundfetcheventinit" id="ref-for-dictdef-backgroundfetcheventinit-1-0">BackgroundFetchEventInit</a> {
+  <span class="kt">required</span> <a class="n" data-link-type="idl-name" href="#enumdef-backgroundfetchstate" id="ref-for-enumdef-backgroundfetchstate-0-0">BackgroundFetchState</a> <a class="nv" data-type="BackgroundFetchState " href="#dom-backgroundfetchclickeventinit-state"><code>state</code></a>;
 };
 
-<span class="kt">enum</span> <a class="nv" href="#enumdef-backgroundfetchstate">BackgroundFetchState</a> { <a class="s" href="#dom-backgroundfetchstate-pending">"pending"</a>, <a class="s" href="#dom-backgroundfetchstate-succeeded">"succeeded"</a>, <a class="s" href="#dom-backgroundfetchstate-failed">"failed"</a> };
+<span class="kt">enum</span> <a class="nv" href="#enumdef-backgroundfetchstate"><code>BackgroundFetchState</code></a> { <a class="s" href="#dom-backgroundfetchstate-pending"><code>"pending"</code></a>, <a class="s" href="#dom-backgroundfetchstate-succeeded"><code>"succeeded"</code></a>, <a class="s" href="#dom-backgroundfetchstate-failed"><code>"failed"</code></a> };
 
 </pre>
   <aside class="dfn-panel" data-for="background-fetch">
    <b><a href="#background-fetch">#background-fetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-background-fetch-1">2. Infrastructure</a>
-    <li><a href="#ref-for-background-fetch-2">3.3. BackgroundFetchRegistration</a>
+    <li><a href="#ref-for-background-fetch">2. Infrastructure</a>
+    <li><a href="#ref-for-background-fetch-0">3.3. BackgroundFetchRegistration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-backgroundfetch">
    <b><a href="#dom-serviceworkerregistration-backgroundfetch">#dom-serviceworkerregistration-backgroundfetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-serviceworkerregistration-backgroundfetch-1">3.1. Extensions to ServiceWorkerRegistration</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-backgroundfetch">3.1. Extensions to ServiceWorkerRegistration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchmanager">
    <b><a href="#backgroundfetchmanager">#backgroundfetchmanager</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchmanager-1">3.1. Extensions to ServiceWorkerRegistration</a> <a href="#ref-for-backgroundfetchmanager-2">(2)</a>
-    <li><a href="#ref-for-backgroundfetchmanager-3">3.2. BackgroundFetchManager</a>
+    <li><a href="#ref-for-backgroundfetchmanager">3.1. Extensions to ServiceWorkerRegistration</a> <a href="#ref-for-backgroundfetchmanager-0">(2)</a>
+    <li><a href="#ref-for-backgroundfetchmanager-1">3.2. BackgroundFetchManager</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-backgroundfetchoptions">
    <b><a href="#dictdef-backgroundfetchoptions">#dictdef-backgroundfetchoptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-backgroundfetchoptions-1">3.2. BackgroundFetchManager</a>
+    <li><a href="#ref-for-dictdef-backgroundfetchoptions">3.2. BackgroundFetchManager</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-icondefinition">
    <b><a href="#dictdef-icondefinition">#dictdef-icondefinition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-icondefinition-1">3.2. BackgroundFetchManager</a>
-    <li><a href="#ref-for-dictdef-icondefinition-2">3.3. BackgroundFetchRegistration</a>
+    <li><a href="#ref-for-dictdef-icondefinition">3.2. BackgroundFetchManager</a>
+    <li><a href="#ref-for-dictdef-icondefinition-0">3.3. BackgroundFetchRegistration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-fetch">
    <b><a href="#dom-backgroundfetchmanager-fetch">#dom-backgroundfetchmanager-fetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchmanager-fetch-1">3.2. BackgroundFetchManager</a>
+    <li><a href="#ref-for-dom-backgroundfetchmanager-fetch">3.2. BackgroundFetchManager</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-get">
    <b><a href="#dom-backgroundfetchmanager-get">#dom-backgroundfetchmanager-get</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchmanager-get-1">3.2. BackgroundFetchManager</a>
+    <li><a href="#ref-for-dom-backgroundfetchmanager-get">3.2. BackgroundFetchManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-gettags">
-   <b><a href="#dom-backgroundfetchmanager-gettags">#dom-backgroundfetchmanager-gettags</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-getidentifiers">
+   <b><a href="#dom-backgroundfetchmanager-getidentifiers">#dom-backgroundfetchmanager-getidentifiers</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchmanager-gettags-1">3.2. BackgroundFetchManager</a>
+    <li><a href="#ref-for-dom-backgroundfetchmanager-getidentifiers">3.2. BackgroundFetchManager</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchregistration">
    <b><a href="#backgroundfetchregistration">#backgroundfetchregistration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchregistration-1">3.2. BackgroundFetchManager</a> <a href="#ref-for-backgroundfetchregistration-2">(2)</a>
-    <li><a href="#ref-for-backgroundfetchregistration-3">3.3. BackgroundFetchRegistration</a> <a href="#ref-for-backgroundfetchregistration-4">(2)</a>
+    <li><a href="#ref-for-backgroundfetchregistration">3.2. BackgroundFetchManager</a> <a href="#ref-for-backgroundfetchregistration-0">(2)</a>
+    <li><a href="#ref-for-backgroundfetchregistration-1">3.3. BackgroundFetchRegistration</a> <a href="#ref-for-backgroundfetchregistration-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchfetch">
    <b><a href="#backgroundfetchfetch">#backgroundfetchfetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchfetch-1">3.3. BackgroundFetchRegistration</a>
-    <li><a href="#ref-for-backgroundfetchfetch-2">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-backgroundfetchfetch">3.3. BackgroundFetchRegistration</a>
+    <li><a href="#ref-for-backgroundfetchfetch-0">3.4.2. BackgroundFetchedEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchactivefetch">
    <b><a href="#backgroundfetchactivefetch">#backgroundfetchactivefetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchactivefetch-1">3.3. BackgroundFetchRegistration</a>
+    <li><a href="#ref-for-backgroundfetchactivefetch">3.3. BackgroundFetchRegistration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetched">
    <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetched">#dom-serviceworkerglobalscope-onbackgroundfetched</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetched-1">3.4. Events</a>
+    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetched">3.4. Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchfail">
    <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchfail">#dom-serviceworkerglobalscope-onbackgroundfetchfail</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchfail-1">3.4. Events</a>
+    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchfail">3.4. Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchabort">
    <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchabort">#dom-serviceworkerglobalscope-onbackgroundfetchabort</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchabort-1">3.4. Events</a>
+    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchabort">3.4. Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchclick">
    <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchclick">#dom-serviceworkerglobalscope-onbackgroundfetchclick</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchclick-1">3.4. Events</a>
+    <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchclick">3.4. Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchevent">
    <b><a href="#backgroundfetchevent">#backgroundfetchevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchevent-1">3.4. Events</a>
-    <li><a href="#ref-for-backgroundfetchevent-2">3.4.1. BackgroundFetchEvent</a> <a href="#ref-for-backgroundfetchevent-3">(2)</a>
-    <li><a href="#ref-for-backgroundfetchevent-4">3.4.2. BackgroundFetchedEvent</a>
-    <li><a href="#ref-for-backgroundfetchevent-5">3.4.4. BackgroundFetchClickEvent</a>
+    <li><a href="#ref-for-backgroundfetchevent">3.4. Events</a>
+    <li><a href="#ref-for-backgroundfetchevent-0">3.4.1. BackgroundFetchEvent</a> <a href="#ref-for-backgroundfetchevent-1">(2)</a>
+    <li><a href="#ref-for-backgroundfetchevent-2">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-backgroundfetchevent-3">3.4.4. BackgroundFetchClickEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-backgroundfetcheventinit">
    <b><a href="#dictdef-backgroundfetcheventinit">#dictdef-backgroundfetcheventinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-backgroundfetcheventinit-1">3.4.1. BackgroundFetchEvent</a>
-    <li><a href="#ref-for-dictdef-backgroundfetcheventinit-2">3.4.2. BackgroundFetchedEvent</a>
-    <li><a href="#ref-for-dictdef-backgroundfetcheventinit-3">3.4.4. BackgroundFetchClickEvent</a>
+    <li><a href="#ref-for-dictdef-backgroundfetcheventinit">3.4.1. BackgroundFetchEvent</a>
+    <li><a href="#ref-for-dictdef-backgroundfetcheventinit-0">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-dictdef-backgroundfetcheventinit-1">3.4.4. BackgroundFetchClickEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchevent-tag">
-   <b><a href="#backgroundfetchevent-tag">#backgroundfetchevent-tag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="backgroundfetchevent-id">
+   <b><a href="#backgroundfetchevent-id">#backgroundfetchevent-id</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchevent-tag-1">3.4.1. BackgroundFetchEvent</a>
+    <li><a href="#ref-for-backgroundfetchevent-id">3.4.1. BackgroundFetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchevent-tag">
-   <b><a href="#dom-backgroundfetchevent-tag">#dom-backgroundfetchevent-tag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-backgroundfetchevent-id">
+   <b><a href="#dom-backgroundfetchevent-id">#dom-backgroundfetchevent-id</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchevent-tag-1">3.4.1. BackgroundFetchEvent</a>
+    <li><a href="#ref-for-dom-backgroundfetchevent-id">3.4.1. BackgroundFetchEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-backgroundfetchevent-backgroundfetchevent">
    <b><a href="#dom-backgroundfetchevent-backgroundfetchevent">#dom-backgroundfetchevent-backgroundfetchevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchevent-backgroundfetchevent-1">3.4.1. BackgroundFetchEvent</a>
+    <li><a href="#ref-for-dom-backgroundfetchevent-backgroundfetchevent">3.4.1. BackgroundFetchEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchedevent">
    <b><a href="#backgroundfetchedevent">#backgroundfetchedevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchedevent-1">3.4. Events</a>
-    <li><a href="#ref-for-backgroundfetchedevent-2">3.4.2. BackgroundFetchedEvent</a>
-    <li><a href="#ref-for-backgroundfetchedevent-3">3.4.3. BackgroundFetchFailEvent</a>
+    <li><a href="#ref-for-backgroundfetchedevent">3.4. Events</a>
+    <li><a href="#ref-for-backgroundfetchedevent-0">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-backgroundfetchedevent-1">3.4.3. BackgroundFetchFailEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-backgroundfetchedeventinit">
    <b><a href="#dictdef-backgroundfetchedeventinit">#dictdef-backgroundfetchedeventinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-backgroundfetchedeventinit-1">3.4.2. BackgroundFetchedEvent</a>
-    <li><a href="#ref-for-dictdef-backgroundfetchedeventinit-2">3.4.3. BackgroundFetchFailEvent</a> <a href="#ref-for-dictdef-backgroundfetchedeventinit-3">(2)</a>
-    <li><a href="#ref-for-dictdef-backgroundfetchedeventinit-4">3.4.4. BackgroundFetchClickEvent</a>
+    <li><a href="#ref-for-dictdef-backgroundfetchedeventinit">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-dictdef-backgroundfetchedeventinit-0">3.4.3. BackgroundFetchFailEvent</a> <a href="#ref-for-dictdef-backgroundfetchedeventinit-1">(2)</a>
+    <li><a href="#ref-for-dictdef-backgroundfetchedeventinit-2">3.4.4. BackgroundFetchClickEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchsettledfetch">
    <b><a href="#backgroundfetchsettledfetch">#backgroundfetchsettledfetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchsettledfetch-1">3.4.2. BackgroundFetchedEvent</a> <a href="#ref-for-backgroundfetchsettledfetch-2">(2)</a>
-    <li><a href="#ref-for-backgroundfetchsettledfetch-3">3.4.3. BackgroundFetchFailEvent</a> <a href="#ref-for-backgroundfetchsettledfetch-4">(2)</a>
+    <li><a href="#ref-for-backgroundfetchsettledfetch">3.4.2. BackgroundFetchedEvent</a> <a href="#ref-for-backgroundfetchsettledfetch-0">(2)</a>
+    <li><a href="#ref-for-backgroundfetchsettledfetch-1">3.4.3. BackgroundFetchFailEvent</a> <a href="#ref-for-backgroundfetchsettledfetch-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-backgroundfetchedevent-updateui">
    <b><a href="#dom-backgroundfetchedevent-updateui">#dom-backgroundfetchedevent-updateui</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchedevent-updateui-1">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-dom-backgroundfetchedevent-updateui">3.4.2. BackgroundFetchedEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-backgroundfetchedevent-backgroundfetchedevent">
    <b><a href="#dom-backgroundfetchedevent-backgroundfetchedevent">#dom-backgroundfetchedevent-backgroundfetchedevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-backgroundfetchedevent-backgroundfetchedevent-1">3.4.2. BackgroundFetchedEvent</a>
+    <li><a href="#ref-for-dom-backgroundfetchedevent-backgroundfetchedevent">3.4.2. BackgroundFetchedEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchfailevent">
    <b><a href="#backgroundfetchfailevent">#backgroundfetchfailevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchfailevent-1">3.4. Events</a>
-    <li><a href="#ref-for-backgroundfetchfailevent-2">3.4.3. BackgroundFetchFailEvent</a>
+    <li><a href="#ref-for-backgroundfetchfailevent">3.4. Events</a>
+    <li><a href="#ref-for-backgroundfetchfailevent-0">3.4.3. BackgroundFetchFailEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="backgroundfetchclickevent">
    <b><a href="#backgroundfetchclickevent">#backgroundfetchclickevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchclickevent-1">3.4. Events</a>
-    <li><a href="#ref-for-backgroundfetchclickevent-2">3.4.4. BackgroundFetchClickEvent</a>
+    <li><a href="#ref-for-backgroundfetchclickevent">3.4. Events</a>
+    <li><a href="#ref-for-backgroundfetchclickevent-0">3.4.4. BackgroundFetchClickEvent</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-backgroundfetchstate">
    <b><a href="#enumdef-backgroundfetchstate">#enumdef-backgroundfetchstate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-backgroundfetchstate-1">3.4.4. BackgroundFetchClickEvent</a> <a href="#ref-for-enumdef-backgroundfetchstate-2">(2)</a>
+    <li><a href="#ref-for-enumdef-backgroundfetchstate">3.4.4. BackgroundFetchClickEvent</a> <a href="#ref-for-enumdef-backgroundfetchstate-0">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
The `tag` is a concept used by the Notification API[1] that implies
uniqueness in a group, which will silently supersede any previous entity
having the same `tag` when it exists.

The `tag` in Background Fetch (and, unfortunately, Background Sync)
implies uniqueness in a group, but reuse will yield an exception instead.
This is a significant difference in behaviour.

Instead, switch to using `id` in Background Fetch. It still implies
uniqueness, but without countering the precedence set by notifications.

[1] https://notifications.spec.whatwg.org/#tag