### PR TITLE
Remove webdriver-spec.html from WebDriver URLs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,7 +27,7 @@ urlPrefix: https://tools.ietf.org/html/rfc7230
   type: dfn
     text: HTTP ABNF; url: section-7
 
-spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#
   type: dfn
     text: extension command; url: dfn-extension-command
     text: extension command URI template; url: dfn-extension-command-uri-template


### PR DESCRIPTION
It redirects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 2, 2020, 10:32 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffoolip%2Fbackground-fetch%2Fa4c49e945d2efdf8c4aa4800eef6f0dac88b280e%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/background-fetch%23150.)._
</details>
