### PR TITLE
Permissions API integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -85,6 +85,10 @@ This specification aims to:
 
 All platform objects are created in the [=context object=]'s [=relevant Realm=] unless otherwise specified.
 
+# Permissions # {#permissions}
+
+<cite>Background Fetch</cite> is a [=default powerful feature=] that is identified by the [=powerful feature/name=] "background-fetch".
+
 # Infrastructure # {#infrastructure}
 
 A resource is considered <dfn>temporarily unavailable</dfn> if the user agent believes the resource may soon become available. Reasons may include:


### PR DESCRIPTION
We are moving stuff out of the Permission API into their own spec - that way, we don't need to keep a "registry". 

This spec already does all the right things with integration into the permissions spec. 

cc @miketaylr


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/background-fetch/pull/161.html" title="Last updated on Oct 14, 2021, 12:39 AM UTC (fa712a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/background-fetch/161/5697424...marcoscaceres:fa712a0.html" title="Last updated on Oct 14, 2021, 12:39 AM UTC (fa712a0)">Diff</a>