### PR TITLE
Define and export "background-fetch" permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -93,7 +93,8 @@ All platform objects are created in [=this=]'s [=relevant Realm=] unless otherwi
 
 # Infrastructure # {#infrastructure}
 
-A resource is considered <dfn>temporarily unavailable</dfn> if the user agent believes the resource may soon become available. Reasons may include:
+A resource is considered <dfn>temporarily unavailable</dfn> if the user agent believes the resource
+may soon become available. Reasons may include:
 
 * The user agent is offline.
 * The user agent is behind a captive portal.

--- a/index.bs
+++ b/index.bs
@@ -88,7 +88,8 @@ All platform objects are created in [=this=]'s [=relevant Realm=] unless otherwi
 
 # Permissions # {#permissions}
 
-<cite>Background Fetch</cite> is a [=default powerful feature=] that is identified by the [=powerful feature/name=] "background-fetch".
+<cite>Background Fetch</cite> is a [=default powerful feature=] that is identified by the
+[=powerful feature/name=] "<dfn permission export>background-fetch</dfn>".
 
 # Infrastructure # {#infrastructure}
 


### PR DESCRIPTION
This way we can link to this eventually from https://github.com/w3c/permissions-registry


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/background-fetch/pull/168.html" title="Last updated on Oct 21, 2022, 6:14 PM UTC (3c9801d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/background-fetch/168/a1f0bc2...miketaylr:3c9801d.html" title="Last updated on Oct 21, 2022, 6:14 PM UTC (3c9801d)">Diff</a>