### PR TITLE
When the background fetch is aborted, use https://streams.spec.whatwg.org/#readablestream-cancel instead of https://streams.spec.whatwg.org/#readablestream-error for upload streams.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -706,7 +706,7 @@ dictionary BackgroundFetchOptions : BackgroundFetchUIOptions {
             1. If |stream| has [=ReadableStream/errored=], then set |requestReadFailed| to true.
 
             Note: This ensures we have a copy of the request bytes before resolving.
-          1. [=If aborted=] and |stream| is [=ReadableStream/readable=], then [=ReadableStream/error=] |stream| with an {{AbortError}} {{DOMException}} and abort these steps.
+          1. [=If aborted=] and |stream| is [=ReadableStream/readable=], then [=ReadableStream/cancel=] |stream| with an {{AbortError}} {{DOMException}} and abort these steps.
           1. Increment |uploadTotal| by |request|'s [=request/body=]'s [=body/length=].
           1. Decrement |requestBodiesRemaining| by 1.
       1. If at any point storing |requests| fails due to exceeding a quota limit, [=reject=] |promise| with a {{QuotaExceededError}} {{DOMException}} and abort these steps.


### PR DESCRIPTION
Fixes https://github.com/WICG/background-fetch/issues/170


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/background-fetch/pull/171.html" title="Last updated on Mar 6, 2023, 12:34 PM UTC (c1a286e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/background-fetch/171/a1f0bc2...youennf:c1a286e.html" title="Last updated on Mar 6, 2023, 12:34 PM UTC (c1a286e)">Diff</a>